### PR TITLE
fix: description not saved add notice page

### DIFF
--- a/frontend/src/domains/notice/components/notice-form.tsx
+++ b/frontend/src/domains/notice/components/notice-form.tsx
@@ -86,7 +86,7 @@ export const NoticeForm: React.FC<Props> = ({
         sx={{ marginTop: '20px' }}
       />
       <TextField
-        {...register('content')}
+        {...register('description')}
         error={Boolean(errors.description)}
         helperText={errors.description?.message}
         type='text'

--- a/frontend/src/domains/notice/pages/add-notice-page.tsx
+++ b/frontend/src/domains/notice/pages/add-notice-page.tsx
@@ -16,7 +16,7 @@ import { NoticeForm } from '../components';
 
 const initialState: NoticeFormProps = {
   title: '',
-  content: '',
+  description: '',
   status: 0,
   recipientType: 'EV',
   recipientRole: 0,


### PR DESCRIPTION
## Issue
Earlier on the "Add New Notice" Page, the "description" is not saved when clicking the "Save" button.

## Solution
Issue is that we are storing data in the wrong variable `content`, we have to update the variable to description.

<img width="1182" alt="Screenshot 2025-03-02 at 1 33 23 PM" src="https://github.com/user-attachments/assets/95a7e7fa-132f-428f-aac9-6a8b3b2a2430" />
